### PR TITLE
perf(mixins-flex-props-main): :technologist: add using of use as impo…

### DIFF
--- a/src/mixins/flex-props/main-props/_order.scss
+++ b/src/mixins/flex-props/main-props/_order.scss
@@ -1,13 +1,13 @@
 @charset "UTF-8";
 @use "../../../abstract/variables" as var;
-@import "../../../functions/global/cut-unit";
+@use "../../../functions/global/cut-unit" as func;
 
 @mixin order($val) {
     @if type-of($val) != number {
         @error "The value of order mixin argument must be of type number.";
     }
 
-    $actual-val: cut-unit($val);
+    $actual-val: func.cut-unit($val);
 
     @each $prop in var.$order-props {
         #{$prop}: $actual-val;


### PR DESCRIPTION
…rt instead of import statement

Before, We used import statement to get the cut-unit function to use it in the order mixin. Now, We replaced it with use statement to improve developer experience.