### PR TITLE
feat(mixins-general): :sparkles: add font-family mixin to generate in…

### DIFF
--- a/src/mixins/general/_font-generator-vars.scss
+++ b/src/mixins/general/_font-generator-vars.scss
@@ -1,0 +1,22 @@
+@use "sass:map";
+
+@mixin ff($fonts) {
+    @if type-of($fonts) != map {
+        @error "Please, Pass a map of font families contains names and values for (ff) mixin.";
+    }
+
+    :root {
+        @each $font-name, $font-val in $fonts {
+            // stylelint-disable-next-line scss/at-if-no-null
+            @if $font-name == "" or $font-name == null {
+                @error "Please, Add a good font family name to generate it!";
+            }
+
+            @if type-of($font-name) != string {
+                @error "Font family name must be in string type.";
+            }
+
+            --#{$font-name}-font: #{$font-val};
+        }
+    }
+}

--- a/src/mixins/general/_index.scss
+++ b/src/mixins/general/_index.scss
@@ -13,3 +13,4 @@
 @forward "keyframe";
 @forward "backdrop";
 @forward "user-select";
+@forward "font-generator-vars";


### PR DESCRIPTION
… root CSS

Add ff mixin to recieve font family names as argument in map type and generate it in the root of document in CSS file.