### PR TITLE
refactor(enhance): :recycle: move align-self props & values in its mixin

### DIFF
--- a/src/abstract/_variables.scss
+++ b/src/abstract/_variables.scss
@@ -162,30 +162,6 @@ $flex-shrink-props: (
 
 $flex-shrink-values: (initial, inherit) !default;
 
-$align-self-props: (
-    -webkit-align-self,
-    -ms-grid-row-align,
-    -ms-align-self,
-    -moz-align-self,
-    -o-align-self,
-    align-self
-) !default;
-
-$align-self-values: (
-    auto,
-    normal,
-    stretch,
-    start,
-    end,
-    self-start,
-    self-end,
-    center,
-    flex-start,
-    flex-end,
-    baseline,
-    inherit
-) !default;
-
 $flex-grow-props: (-webkit-flex-grow, -webkit-box-flex, -ms-flex-positive, -moz-box-flex, flex-grow) !default;
 
 $flex-basis-props: (

--- a/src/mixins/flex-props/main-props/_align-self.scss
+++ b/src/mixins/flex-props/main-props/_align-self.scss
@@ -1,15 +1,39 @@
 @charset "UTF-8";
 @use "sass:list";
-@use "../../../abstract/variables" as var;
 @import "../../../functions";
 
 @mixin align-self($val: auto) {
+    $align-self-props: (
+        -webkit-align-self,
+        -ms-grid-row-align,
+        -ms-align-self,
+        -moz-align-self,
+        -o-align-self,
+        align-self
+    ) !default;
+
+    // stylelint-disable-next-line scss/dollar-variable-empty-line-before
+    $align-self-values: (
+        auto,
+        normal,
+        stretch,
+        start,
+        end,
+        self-start,
+        self-end,
+        center,
+        flex-start,
+        flex-end,
+        baseline,
+        inherit
+    ) !default;
+
     @if type-of($val) != string {
         @error "$val of align-self argument must be of type string.";
     }
 
-    @if is-in-list(var.$align-self-values, $val) {
-        @each $prop in var.$align-self-props {
+    @if is-in-list($align-self-values, $val) {
+        @each $prop in $align-self-props {
             #{$prop}: $val;
         }
     }


### PR DESCRIPTION
Move the properties and values of the align-self property to be private for only the mixin. It will not be used as a global in all app.

Fix #126