### PR TITLE
refactor(enhance): :recycle: move flex-grow props & values in its mixin

### DIFF
--- a/src/abstract/_variables.scss
+++ b/src/abstract/_variables.scss
@@ -120,8 +120,6 @@ $flex-shrink-props: (
 
 $flex-shrink-values: (initial, inherit) !default;
 
-$flex-grow-props: (-webkit-flex-grow, -webkit-box-flex, -ms-flex-positive, -moz-box-flex, flex-grow) !default;
-
 $order-props: (
     -webkit-box-ordinal-group,
     -webkit-order,

--- a/src/mixins/flex-props/main-props/_flex-grow.scss
+++ b/src/mixins/flex-props/main-props/_flex-grow.scss
@@ -1,14 +1,19 @@
 @charset "UTF-8";
 @use "sass:list";
-@use "../../../abstract/variables" as var;
 @import "../../../functions/global/cut-unit";
 
 @mixin flex-grow($val: 0) {
+    $flex-grow-props: (-webkit-flex-grow, -webkit-box-flex, -ms-flex-positive, -moz-box-flex, flex-grow) !default;
+
     @if type-of($val) != number {
         @error "$val of flex-grow argument must be of type number.";
     }
 
-    @each $prop in var.$flex-grow-props {
+    @if $val < 0 {
+        @error "The value of flex-grow argument must be bigger than or equal to zero.";
+    }
+
+    @each $prop in $flex-grow-props {
         #{$prop}: cut-unit($val);
     }
 }


### PR DESCRIPTION
Move the properties and values of the flex-grow property to be private for only the mixin. It will not be used as a global in all app.

Fix #132