### PR TITLE
refactor(enhance): :recycle: move flex-wrap props in its mixin

### DIFF
--- a/src/abstract/_variables.scss
+++ b/src/abstract/_variables.scss
@@ -107,8 +107,6 @@ $flex-direction-row-values: (horizontal, normal, row, row) !default;
 
 $flex-direction-row-reverse-values: (horizontal, reverse, row-reverse, row-reverse) !default;
 
-$flex-wrap-values: (nowrap, wrap, wrap-reverse, "", no, yes, w, wrap-rev, w-rev, inherit) !default;
-
 $order-props: (
     -webkit-box-ordinal-group,
     -moz-box-ordinal-group,

--- a/src/mixins/flex-props/main-props/_flex-wrap.scss
+++ b/src/mixins/flex-props/main-props/_flex-wrap.scss
@@ -1,12 +1,13 @@
 @charset "UTF-8";
 @use "sass:list";
 @use "sass:math";
-@use "../../../abstract/variables" as var;
 @use "../../vendor-prefixes/prefix" as pref;
 @use "../../../functions/global/is-in-list" as func;
 
 @mixin flex-wrap($val: nowrap) {
-    @if func.is-in-list(var.$flex-wrap-values, $val) {
+    $flex-wrap-values: (nowrap, wrap, wrap-reverse, "", no, yes, w, wrap-rev, w-rev, inherit) !default;
+
+    @if func.is-in-list($flex-wrap-values, $val) {
         @if $val == "" or $val == no or $val == nowrap {
             @include pref.prefixing-ms(flex-wrap, nowrap);
         } @else if $val == wrap or $val == w or $val == yes {


### PR DESCRIPTION
Move the properties of the flex-wrap property to be private for only the mixin. It will not be used as a global in all app.

Fix #136