### PR TITLE
test(tests): :white_check_mark: add pixel-to-rem tests & add forwardi…

### DIFF
--- a/tests/functions/converters/_index.scss
+++ b/tests/functions/converters/_index.scss
@@ -24,12 +24,6 @@
 // @see cm-to-px
 @forward "centimeter-to-pixel.test";
 
-// * decimal to percentage forward.
-// * forwarding the testing dec-to-ptg function.
-// * please see the `dec-to-ptg` function for details.
-// @see dec-to-ptg
-@forward "decimal-to-percentage.test";
-
 // * inches to centimeter forward.
 // * forwarding the testing in-to-cm function.
 // * please see the `in-to-cm` function for details.
@@ -42,12 +36,6 @@
 // @see in-to-px
 @forward "inches-to-px.test";
 
-// * percentage to decimal forward.
-// * forwarding the testing ptg-to-dec function.
-// * please see the `ptg-to-dec` function for details.
-// @see ptg-to-dec
-@forward "percentage-to-decimal.test";
-
 // * pixel to centimeter forward.
 // * forwarding the testing px-to-cm function.
 // * please see the `px-to-cm` function for details.
@@ -59,3 +47,21 @@
 // * please see the `px-to-in` function for details.
 // @see px-to-in
 @forward "pixel-to-inches.test";
+
+// * pixel to rem forward.
+// * forwarding the testing px-to-rem function.
+// * please see the `px-to-rem` function for details.
+// @see px-to-rem
+@forward "pixel-to-rem.test";
+
+// * percentage to decimal forward.
+// * forwarding the testing ptg-to-dec function.
+// * please see the `ptg-to-dec` function for details.
+// @see ptg-to-dec
+@forward "percentage-to-decimal.test";
+
+// * decimal to percentage forward.
+// * forwarding the testing dec-to-ptg function.
+// * please see the `dec-to-ptg` function for details.
+// @see dec-to-ptg
+@forward "decimal-to-percentage.test";

--- a/tests/functions/converters/_pixel-to-rem.test.scss
+++ b/tests/functions/converters/_pixel-to-rem.test.scss
@@ -1,0 +1,54 @@
+@charset "UTF-8";
+
+// @description
+// * px-to-rem function.
+// * This module tests a functionality of px-to-rem function.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/krypton225/sass-pire
+
+// @namespace converters
+
+// @module converters/px-to-rem.test
+
+// @dependencies:
+// * - true.describe (true function).
+// * - true.it (true function).
+// * - true.assert-equal (true function).
+// * - err (function).
+
+// stylelint-disable number-max-precision
+
+@use "../../../node_modules/sass-true/sass/true" as *;
+@use "../../../src/functions/converters/pixel-to-rem" as func;
+@use "../../../src/development-utils/error" as dev;
+
+$test-cases-px-to-rem-map: (
+    0: 0,
+    0px: dev.err("The parameter dose not need a unit if it equals to zero."),
+    344px: "21.5rem",
+    -0.5px: "-0.031rem",
+    -92px: "-5.75rem",
+    80px: "5rem",
+    5.82px: "0.364rem",
+    212px: "13.25rem",
+    "Just a number": dev.err("The parameter of px-to-rem function must be in a number type."),
+    true: dev.err("The parameter of px-to-rem function must be in a number type."),
+    false: dev.err("The parameter of px-to-rem function must be in a number type."),
+    (1, 2, 4): dev.err("The parameter of px-to-rem function must be in a number type.")
+);
+
+@each $case, $result in $test-cases-px-to-rem-map {
+    @include describe("[Function] px-to-rem(#{$case}), Result: #{$result}") {
+        @include it("Convert a value in pixel to inches.") {
+            @include assert-equal(func.px-to-rem($case), $result);
+        }
+    }
+}


### PR DESCRIPTION
…ng converters

Add pixel-to-rem test module to include comprehensive test cases for the px-to-rem function. No issues addressed.

Fix #249