### PR TITLE
refactor(enhance): :recycle: Refactor `half` function to handle non-u…

### DIFF
--- a/src/functions/global/_get-half-number.scss
+++ b/src/functions/global/_get-half-number.scss
@@ -57,7 +57,12 @@
 
 @function half($number) {
     @if meta.type-of($number) != number {
-        @return Error.toggle("You must pass a value in type number to cut-unit function.");
+        @return Error.toggle("The parameter of half function must be in a number type.");
+    }
+
+    @if LibFunc.cut-unit($number) == 0 {
+        @debug math.unit($number);
+        @return 0;
     }
 
     @if not unitless($number) {
@@ -68,4 +73,8 @@
     }
 
     @return calc($number / 2);
+}
+
+.example {
+    font-size: half(10rem);
 }


### PR DESCRIPTION
…nitless inputs

Adjusted the `half` function to properly handle non-unitless input by returning 0 when the input has units. This prevents unexpected behavior and aligns with the function's intended functionality. The added example usage demonstrates the updated behavior. No associated issues.