### PR TITLE
test(tests): :white_check_mark: Add unit tests for the `half` function

### DIFF
--- a/src/functions/global/_get-half-number.scss
+++ b/src/functions/global/_get-half-number.scss
@@ -61,7 +61,6 @@
     }
 
     @if LibFunc.cut-unit($number) == 0 {
-        @debug math.unit($number);
         @return 0;
     }
 

--- a/tests/functions/global/_get-half-number.test.scss
+++ b/tests/functions/global/_get-half-number.test.scss
@@ -1,0 +1,55 @@
+@charset "UTF-8";
+
+// @description
+// * half function.
+// * This module tests a functionality of half function.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/krypton225/sass-pire
+
+// @namespace converters
+
+// @module converters/get-half-number.test
+
+// @dependencies:
+// * - true.describe (true function).
+// * - true.it (true function).
+// * - true.assert-equal (true function).
+// * - err (function).
+
+// stylelint-disable number-max-precision
+
+@use "../../../node_modules/sass-true/sass/true" as *;
+@use "../../../src/functions/global/get-half-number" as func;
+@use "../../../src/development-utils/error" as dev;
+
+$test-cases-half-map: (
+    0: 0,
+    0px: 0,
+    344px: "172px",
+    -0.5px: "-0.25px",
+    -92rem: "-46rem",
+    94vh: "47vh",
+    80px: "40px",
+    5.82px: "2.91px",
+    212px: "106px",
+    "Just a number": dev.err("The parameter of half function must be in a number type."),
+    true: dev.err("The parameter of half function must be in a number type."),
+    false: dev.err("The parameter of half function must be in a number type."),
+    (1, 2, 4): dev.err("The parameter of half function must be in a number type.")
+);
+
+@each $case, $result in $test-cases-half-map {
+    @include describe("[Function] half(#{$case}), Result: #{$result}") {
+        @include it("Cut the unit of (#{$case}) value.") {
+            @include assert-equal(func.half($case), $result);
+        }
+    }
+}

--- a/tests/functions/global/_index.scss
+++ b/tests/functions/global/_index.scss
@@ -17,3 +17,9 @@
 // * please see testing `cut-unit` function for details.
 // @see cut-unit
 @forward "cut-unit.test";
+
+// * half forward.
+// * forwarding the testing half function.
+// * please see testing `half` function for details.
+// @see half
+@forward "get-half-number.test";


### PR DESCRIPTION
Add unit tests for the `half` function to ensure it handles various input cases correctly, including cutting units and handling error cases. This will help maintain the functionality and reliability of the half function. Refactor code coverage is improved. No associated issues.

Fix #251