### PR TITLE
test(tests): :white_check_mark: Add test module for `get-first-from` …

### DIFF
--- a/tests/functions/list/_get-first-element.test.scss
+++ b/tests/functions/list/_get-first-element.test.scss
@@ -1,0 +1,50 @@
+@charset "UTF-8";
+
+// @description
+// * get-first-from function.
+// * This module tests a functionality of get-first-from function.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/krypton225/sass-pire
+
+// @namespace list
+
+// @module list/get-first-element.test
+
+// @dependencies:
+// * - True.describe (true function).
+// * - True.it (true function).
+// * - True.assert-equal (true function).
+// * - Dev.err (function).
+
+// stylelint-disable function-name-case
+
+@use "sass:map";
+@use "../../../node_modules/sass-true/sass/true" as True;
+@use "../../../src/functions/list/get-first-element" as LibFunc;
+@use "../../../src/development-utils/error" as Dev;
+
+$test-cases-get-first-from-map: (
+    (1, 2, 4): 1,
+    344px: Dev.err("The parameter of get-first-from function must be in a list type."),
+    (69, 48, 54, (32, (11, 43))): 69,
+    ((true, false), (0, "Just a text"), (2, 32, 4)): true,
+    (89, 48, 54, (32, (11, 43, (21, (11, "Yes"))))): 89,
+    true: Dev.err("The parameter of get-first-from function must be in a list type."),
+    "Just a number": Dev.err("The parameter of get-first-from function must be in a list type.")
+);
+
+@each $case, $result in $test-cases-get-first-from-map {
+    @include True.describe("[Function] get-first-from(#{$case}), Result: #{$result}") {
+        @include True.it("get-first-from( #{$case}).") {
+            @include True.assert-equal(LibFunc.get-first-from($case), $result);
+        }
+    }
+}

--- a/tests/functions/list/_index.scss
+++ b/tests/functions/list/_index.scss
@@ -23,3 +23,9 @@
 // * please see testing `center-of-list` function for details.
 // @see center-of-list
 @forward "get-centered-element-list.test";
+
+// * get-first-element-list forward.
+// * forwarding the testing get-first-from function.
+// * please see testing `get-first-from` function for details.
+// @see get-first-from
+@forward "get-first-element.test";


### PR DESCRIPTION
…function in list module

Add a new test module for the `get-first-from` function to ensure its correctness and robustness. This enhances code reliability and facilitates maintenance. No significant side effects foreseen.

Fix #257