### PR TITLE
test(tests): :white_check_mark: Forward testing `merge` function for …

### DIFF
--- a/tests/functions/list/_index.scss
+++ b/tests/functions/list/_index.scss
@@ -35,3 +35,9 @@
 // * please see testing `get-last-from` function for details.
 // @see get-last-from
 @forward "get-last-element.test";
+
+// * merge-list forward.
+// * forwarding the testing merge function.
+// * please see testing `merge` function for details.
+// @see merge
+@forward "merge.test";

--- a/tests/functions/list/_merge.test.scss
+++ b/tests/functions/list/_merge.test.scss
@@ -1,0 +1,50 @@
+@charset "UTF-8";
+
+// @description
+// * merge function.
+// * This module tests a functionality of merge function.
+
+// @access private
+
+// @version 1.0.0
+
+// @author Khaled Mohamed
+
+// @license MIT
+
+// @repository: https://github.com/krypton225/sass-pire
+
+// @namespace list
+
+// @module list/merge.test
+
+// @dependencies:
+// * - True.describe (true function).
+// * - True.it (true function).
+// * - True.assert-equal (true function).
+// * - Dev.err (function).
+
+// stylelint-disable function-name-case
+
+@use "sass:map";
+@use "../../../node_modules/sass-true/sass/true" as True;
+@use "../../../src/functions/list/merge" as LibFunc;
+@use "../../../src/development-utils/error" as Dev;
+
+$test-cases-merge-map: (
+    (1, 2, 4): (1 2 4),
+    344px: Dev.err("The parameter of merge function must be in a list type."),
+    (69, 48, 54, (32, (11, 43))): (69 48 54 32 11 43),
+    ((true, false), (0, "Just a text"), (2, 32, 4)): (true false 0 "Just a text" 2 32 4),
+    (89, 48, 54, (32, (11, 43, (21, (11, "Yes"))))): (89 48 54 32 11 43 21 11 "Yes"),
+    true: Dev.err("The parameter of merge function must be in a list type."),
+    "Just a number": Dev.err("The parameter of merge function must be in a list type.")
+);
+
+@each $case, $result in $test-cases-merge-map {
+    @include True.describe("[Function] merge(#{$case}), Result: #{$result}") {
+        @include True.it("merge( #{$case}).") {
+            @include True.assert-equal(LibFunc.merge($case), $result);
+        }
+    }
+}


### PR DESCRIPTION
…list module

Added a new test suite `merge.test.scss` to forward the testing of the `merge` function for the list module, ensuring accurate functionality assessment through various parameter scenarios. This enhances the robustness of the list module and promotes reliable codebase maintenance.

Fix #259