### PR TITLE
docs(docs): :memo: Update `grid-col` mixin to use string values for g…

### DIFF
--- a/src/mixins/grid-props/_grid-column.scss
+++ b/src/mixins/grid-props/_grid-column.scss
@@ -22,6 +22,10 @@
 
 // @dependencies:
 // * - meta.type-of (SASS function).
+// * - list.length (SASS function).
+// * - list.nth (SASS function).
+// * - string.unquote (SASS function).
+// * - string.split (SASS function).
 // * - LibFunc.is-in-list (function).
 // * - Error.toggle (function).
 
@@ -31,14 +35,14 @@
 
 // @example
 // * .example {
-// *   @include grid-col(12rem);
+// *   @include grid-col("2 / span 3");
 // * }
 
 // @output:
 // * .example {
-// *   -webkit-column-gap: 12rem;
-// *   -moz-column-gap: 12rem;
-// *   column-gap: 12rem;
+// *   -ms-grid-column: 2;
+// *   -ms-grid-column-span: span 3;
+// *   grid-column: 2 / span 3;
 // * }
 
 @use "sass:meta";


### PR DESCRIPTION
…rid placement

This change updates the `grid-col` mixin to accept string values for grid placement (e.g., "2 / span 3") instead of solely numeric values. This provides more flexibility and aligns with modern CSS grid layout practices. It also requires the addition of several SASS functions to support the string manipulation.