### PR TITLE
feat(base): :children_crossing: Add `hyphens` & `overflow-wrap` props…

### DIFF
--- a/src/base/_reset.scss
+++ b/src/base/_reset.scss
@@ -56,6 +56,12 @@ html:focus-within {
 body {
     min-height: 100vh;
     line-height: 1.5;
+
+    // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
+    :where(&) {
+        hyphens: auto;
+        overflow-wrap: break-word;
+    }
 }
 
 // * A elements that don't have a class get default styles


### PR DESCRIPTION
… to body in `where` selector